### PR TITLE
fix: fix the fixed timeout issue

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to the "flutter-fuse" extension will be documented in this f
 
 Check [Keep a Changelog](http://keepachangelog.com/) for recommendations on how to structure this file.
 
+## [0.0.2] - 2023-09-17
+  
+### Changed
+- The hard-coded waiting timeout was fixed with even-driven async solution.
+
 ## [Unreleased]
 
 - Initial release

--- a/README.md
+++ b/README.md
@@ -1,7 +1,6 @@
+#
 
-# 
-
-The "Flutter Fuse" extension is a Visual Studio Code extension for working with Flutter projects. 
+The "Flutter Fuse" extension is a Visual Studio Code extension for working with Flutter projects.
 
 If you have been working with Flutter for a while, you know that sometimes it can get very boring and repetitive to fix imports of the .dart files, specially if you are using the "Quick Fix" option manually.
 
@@ -9,39 +8,35 @@ Of course there are multiple extensions available and the VS Code's `Fix All` an
 
 ## Why this extension?
 
-- Recently I hopped into an old Flutter project where I wanted to refactor some code. There were a lot of dart files and when I moved them into different folders, the imports didn't update as I expected, for some reason. I wasted a lot of time manually "Quick Fix" ing them. Also, I could't find an extension which already does that. So, meet Flutter Fuse. 
+- Recently I hopped into an old Flutter project where I wanted to refactor some code. There were a lot of dart files and when I moved them into different folders, the imports didn't update as I expected, for some reason. I wasted a lot of time manually "Quick Fix" ing them. Also, I could't find an extension which already does that. So, meet Flutter Fuse.
 
 Any by the way, this is my very first Flutter extension! So I'm happy that I got it published on VS Code Marketplace! 😊
 
 ## Features
 
 - Fix imports in the current .dart file
-This extension will automatically import the relevant files required for the current .dart file. Also after importing, it'll run the `Fix All` option to try to fix if duplicate imports are there. (Like cupertino and material). But this is not fully tested.
-
+  This extension will automatically import the relevant files required for the current .dart file. Also after importing, it'll run the `Fix All` option to try to fix if duplicate imports are there. (Like cupertino and material). But this is not fully tested.
 
 ## Demo
 
 ![App Demo](https://im2.ezgif.com/tmp/ezgif-2-03aaa15e5e.gif)
 
-
 ## Known Issues
 
-- If the imports are not resolved within 10 seconds, you'll have to run the `Flutter Fuse: Fix Imports` command again.
-- If errors that are not "Quick Fix" able exists, the importing process will run for 10 seconds and then timeout.
+- Deprecated package imports are not handled.
+
 ## Roadmap
 
 - Give an option to fix imports in whole project instead of just the currently opened .dart file
-
 
 ## License
 
 [MIT](https://choosealicense.com/licenses/mit/)
 
-
 ## 🚀 About Me
-I'm RukshanJS and still learning this stuff. Have experience with Flutter for 2.5+ years. (Mostly worked with Flutter 2 though) 
+
+I'm RukshanJS and still learning this stuff. Have experience with Flutter for 2.5+ years. (Mostly worked with Flutter 2 though)
 
 You can connect with me on LinkedIn, I'd be happy to get in touch!
 
 Have a nice day 😃
-

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "flutter-fuse",
   "displayName": "Flutter Fuse",
   "description": "Better Import Management for Flutter",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "publisher": "RukshanJS",
   "icon": "icons/flutter-fuse.png",
   "repository": {

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -1,94 +1,87 @@
-
 import * as vscode from 'vscode';
 import { Diagnostic, Range, TextDocument } from 'vscode';
 
 export function activate(context: vscode.ExtensionContext) {
-    let continueLooping = false;
+  console.log('Flutter Fuse: Congratulations, your extension "Flutter Fuse" is now active!');
 
-    // TODO - Make this better
-    const MAX_TIMEOUT = 10000; // Maximum timeout in milliseconds
+  let disposable = vscode.commands.registerCommand('flutter-fuse.quickFix', async () => {
+    const editor = vscode.window.activeTextEditor;
+    if (!editor) {
+      vscode.window.showErrorMessage('Flutter Fuse: No active text editor found.');
+      return;
+    }
 
-    let importErrors: Diagnostic[];
+    await vscode.window.withProgress(
+      {
+        location: vscode.ProgressLocation.Notification,
+        title: 'Flutter Fuse: Fixing import errors...',
+        cancellable: true,
+      },
+      async (progress, token) => {
+        try {
+          const document = editor.document;
 
-	console.log('Flutter Fuse: Congratulations, your extension "Flutter Fuse" is now active!');
-
-	let disposable = vscode.commands.registerCommand('flutter-fuse.quickFix', async() => {
-        // Start looping for errors
-        continueLooping = true;
-
-		const editor = vscode.window.activeTextEditor;
-        if (!editor) {
-            vscode.window.showErrorMessage('Flutter Fuse: No active text editor found.');
-            return;
-        }
-
-        await vscode.window.withProgress({
-            location: vscode.ProgressLocation.Notification,
-            title: "Flutter Fuse: Fixing import errors...",
-            cancellable: true
-        }, async (progress, token) => {
-            let continueLooping = true;
-            const timeout = setTimeout(() => {
-                continueLooping = false;
-            }, MAX_TIMEOUT);
-        
-            try {
-                const document = editor.document;
-                let importErrors = getImportErrors(document);
-        
-                while (importErrors.length > 0 && continueLooping && !token.isCancellationRequested) {
-                    for (const diagnostic of importErrors) {
-                        await applyQuickFix(document, diagnostic.range);
-                    }
-                    importErrors = getImportErrors(document);
-                    progress.report({ increment: 1 });
-                }
-        
-                if (!continueLooping) {
-                    vscode.window.showWarningMessage("Flutter Fuse: Import fixing operation timed out. Some imports may not have been fixed.");
-                } else if (token.isCancellationRequested) {
-                    vscode.window.showInformationMessage("Flutter Fuse: Import fixing operation canceled.");
-                } else {
-                    vscode.window.showInformationMessage("Flutter Fuse: Import fixing operation completed successfully.");
-                }
-            } finally {
-                clearTimeout(timeout);
+          const changeDiagnosticListener = vscode.languages.onDidChangeDiagnostics(async (e) => {
+            if (e.uris.some((uri) => uri.toString() === document.uri.toString())) {
+              const importErrors = getImportErrors(document);
+              if (importErrors.length === 0) {
+                changeDiagnosticListener.dispose();
+                vscode.window.showInformationMessage('Flutter Fuse: Import fixing operation completed successfully.');
+              }
             }
-        });
+          });
 
-        
-	});
+          await fixAllImportErrors(document, progress);
 
-	context.subscriptions.push(disposable);
+          if (token.isCancellationRequested) {
+            changeDiagnosticListener.dispose();
+            vscode.window.showInformationMessage('Flutter Fuse: Import fixing operation canceled.');
+          }
+        } catch (err) {
+          vscode.window.showErrorMessage(`Flutter Fuse: An error occurred: ${err}`);
+        }
+      }
+    );
+  });
+
+  context.subscriptions.push(disposable);
 }
 
 function getImportErrors(document: TextDocument): vscode.Diagnostic[] {
-    const diagnostics = vscode.languages.getDiagnostics(document.uri);
-    return diagnostics.filter(diagnostic => diagnostic.severity === vscode.DiagnosticSeverity.Error);
+  const diagnostics = vscode.languages.getDiagnostics(document.uri);
+  return diagnostics.filter((diagnostic) => diagnostic.severity === vscode.DiagnosticSeverity.Error);
+}
+
+async function fixAllImportErrors(document: TextDocument, progress: vscode.Progress<{ increment: number }>): Promise<void> {
+  let importErrors = getImportErrors(document);
+  while (importErrors.length > 0) {
+    for (const diagnostic of importErrors) {
+      await applyQuickFix(document, diagnostic.range);
+    }
+    // Re-fetch diagnostics
+    await new Promise((resolve) => setTimeout(resolve, 300)); // Give some time for diagnostics to update
+    importErrors = getImportErrors(document);
+    progress.report({ increment: 1 });
+  }
 }
 
 async function applyQuickFix(document: TextDocument, range: Range): Promise<void> {
-    const codeActions = await vscode.commands.executeCommand<vscode.CodeAction[]>('vscode.executeCodeActionProvider', document.uri, range);
+  const codeActions = await vscode.commands.executeCommand<vscode.CodeAction[]>('vscode.executeCodeActionProvider', document.uri, range);
 
-    if (!codeActions) {
-        return;
-    }
+  if (!codeActions) {
+    return;
+  }
 
-    const importAction = codeActions.find(action => action.title.startsWith('Import'));
-    if (!importAction) {
-        return;
-    }
+  const importAction = codeActions.find((action) => action.title.startsWith('Import'));
+  if (!importAction) {
+    return;
+  }
 
-    if (importAction.command) {
-        await vscode.commands.executeCommand(importAction.command.command, ...(importAction.command.arguments || []));
-    } else if (importAction.edit) {
-        await vscode.workspace.applyEdit(importAction.edit);
-    }
-}
-
-async function fixAllAndOrganizeImports(): Promise<void> {
-    await vscode.commands.executeCommand('editor.action.fixAll');
-	return;
+  if (importAction.command) {
+    await vscode.commands.executeCommand(importAction.command.command, ...(importAction.command.arguments || []));
+  } else if (importAction.edit) {
+    await vscode.workspace.applyEdit(importAction.edit);
+  }
 }
 
 export function deactivate() {}


### PR DESCRIPTION
Fixes Timeout error - #5 

How the fix was done is mainly concerned with the `fixAllImportErrors` function. This function utilizes an asynchronous `while` loop to continuously check for import errors. Within the loop, for each import error diagnostic, it asynchronously calls `applyQuickFix` to fix it. After fixing, the loop deliberately waits for 300 milliseconds to give VSCode's internal diagnostics time to update. This ensures that the `getImportErrors` function, which fetches updated diagnostics, will reflect the most recent state of the document.

Additionally, the extension uses `vscode.languages.onDidChangeDiagnostics` to listen for any changes in diagnostics. When the diagnostics change and no import errors are left, it disposes of the listener and shows a success message. All these operations are performed asynchronously.